### PR TITLE
add parameter for base_link

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -8,6 +8,7 @@ lio_sam:
 
   # Frames
   lidarFrame: "base_link"
+  baselinkFrame: "base_link"
   odometryFrame: "odom"
   mapFrame: "map"
 

--- a/include/utility.h
+++ b/include/utility.h
@@ -72,6 +72,7 @@ public:
 
     //Frames
     string lidarFrame;
+    string baselinkFrame;
     string odometryFrame;
     string mapFrame;
 
@@ -152,6 +153,7 @@ public:
         nh.param<std::string>("lio_sam/gpsTopic", gpsTopic, "odometry/gps");
 
         nh.param<std::string>("lio_sam/lidarFrame", lidarFrame, "base_link");
+        nh.param<std::string>("lio_sam/baselinkFrame", baselinkFrame, "base_link");
         nh.param<std::string>("lio_sam/odometryFrame", odometryFrame, "odom");
         nh.param<std::string>("lio_sam/mapFrame", mapFrame, "map");
 


### PR DESCRIPTION
This PR builds upon PR #41 and fixes issue #40.
In most robotics setups the tf tree looks similar to this example: `map`->`odom`->`base_link`->`lidar_frame`
In many cases, the `base_link` does not coincide with the `lidar_frame`.

With the current parameters, it is only possible to rename the `base_link`, using the `lidarFrame` parameter. The result is a direct connection from `odom` to `lidar_frame` and the base_link is not used at all: `map`->`odom`->`lidar_frame`

My proposed solution is the introduction of an additional `base_link` parameter. 
Now, when the node gets launched the transform from the `lidar_frame` to `base_link` gets stored.
The odometry is calculated in the `lidar_frame` and the result is a transform from `odom` to `lidar_frame` so that multiplying the `lidar_frame` to `base_link` transform results in the desired `odom` to `base_link` transform.

By default, the original hardcoded frames are used and these steps are completely ignored when the `base_link` is the same as the `lidar_frame`. So this PR does not result in any changes for existing setups.