### PR TITLE
Fix a parallelism bug in transformPointCloud()

### DIFF
--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -278,8 +278,6 @@ public:
     {
         pcl::PointCloud<PointType>::Ptr cloudOut(new pcl::PointCloud<PointType>());
 
-        PointType *pointFrom;
-
         int cloudSize = cloudIn->size();
         cloudOut->resize(cloudSize);
 
@@ -288,11 +286,11 @@ public:
         #pragma omp parallel for num_threads(numberOfCores)
         for (int i = 0; i < cloudSize; ++i)
         {
-            pointFrom = &cloudIn->points[i];
-            cloudOut->points[i].x = transCur(0,0) * pointFrom->x + transCur(0,1) * pointFrom->y + transCur(0,2) * pointFrom->z + transCur(0,3);
-            cloudOut->points[i].y = transCur(1,0) * pointFrom->x + transCur(1,1) * pointFrom->y + transCur(1,2) * pointFrom->z + transCur(1,3);
-            cloudOut->points[i].z = transCur(2,0) * pointFrom->x + transCur(2,1) * pointFrom->y + transCur(2,2) * pointFrom->z + transCur(2,3);
-            cloudOut->points[i].intensity = pointFrom->intensity;
+            const auto &pointFrom = cloudIn->points[i];
+            cloudOut->points[i].x = transCur(0,0) * pointFrom.x + transCur(0,1) * pointFrom.y + transCur(0,2) * pointFrom.z + transCur(0,3);
+            cloudOut->points[i].y = transCur(1,0) * pointFrom.x + transCur(1,1) * pointFrom.y + transCur(1,2) * pointFrom.z + transCur(1,3);
+            cloudOut->points[i].z = transCur(2,0) * pointFrom.x + transCur(2,1) * pointFrom.y + transCur(2,2) * pointFrom.z + transCur(2,3);
+            cloudOut->points[i].intensity = pointFrom.intensity;
         }
         return cloudOut;
     }


### PR DESCRIPTION
The unintentional sharing of a pointer between OMP threads currently causes parts of the transformed cloud to become corrupted.

### Before
![before](https://user-images.githubusercontent.com/1778160/101539798-bf7e9e00-39a7-11eb-9d57-eba5172badbb.png)

### After
![after](https://user-images.githubusercontent.com/1778160/101539821-c86f6f80-39a7-11eb-99eb-fe4e3db485eb.png)

The images are not of the exact same scan, but note the lack of points scattered randomly above the sensor in the after image.
The cloud being displayed is from the `lio_sam/mapping/cloud_registered` topic.