### PR TITLE
Add ability to correct for IMU axis misalignment using params.yaml

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -37,6 +37,15 @@ lio_sam:
   imuGyrBiasN: 3.5640318696367613e-05
   imuGravity: 9.80511
   imuRPYWeight: 0.01
+  imuAccAlignment: [1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1]
+  imuGyrAlignment: [1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1]
+  imuMagAlignment: [1, 0, 0,
+                    0, 1, 0,
+                    0, 0, 1]
 
   # Extrinsics (lidar -> IMU)
   extrinsicTrans: [0.0, 0.0, 0.0]


### PR DESCRIPTION
This is to correct for axis misalignment in IMU sensors. In the "ideal IMU", the 3 axes would be orthogonal, but due to manufacturing tolerances, they are not.

The 3 matrices added to params.yaml allow the user to provide the axis alignment in the form of a 3x3 matrix for each of the 3 axis sensors. Then the IMU data is then pre-multiplied with the inverse of these misalignment matrices in order to make the IMU data "more orthogonal".

So in a sentence, it enables more detailed IMU calibration to help algorithm performance.