### PR TITLE
give name to nodes

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -1,4 +1,4 @@
-/lio_sam*:
+/**:
   ros__parameters:
 
     # Topics

--- a/launch/run.launch.py
+++ b/launch/run.launch.py
@@ -42,24 +42,28 @@ def generate_launch_description():
         Node(
             package='lio_sam',
             executable='lio_sam_imuPreintegration',
+            name='lio_sam_imuPreintegration',
             parameters=[parameter_file],
             output='screen'
         ),
         Node(
             package='lio_sam',
             executable='lio_sam_imageProjection',
+            name='lio_sam_imageProjection',
             parameters=[parameter_file],
             output='screen'
         ),
         Node(
             package='lio_sam',
             executable='lio_sam_featureExtraction',
+            name='lio_sam_featureExtraction',
             parameters=[parameter_file],
             output='screen'
         ),
         Node(
             package='lio_sam',
             executable='lio_sam_mapOptimization',
+            name='lio_sam_mapOptimization',
             parameters=[parameter_file],
             output='screen'
         ),


### PR DESCRIPTION
With current form, the parameters are not being overridded by the ones you set from Yaml file, I suspect its due to wrong prefix. It took quite a lot of time to realize that. I am not sure how you were able to run, maybe your topics were just identical to the defaulkt ones that you assign [here](https://github.com/TixiaoShan/LIO-SAM/blob/0f4908b963ee303fbb6ae941477d6a2efa5c454f/include/lio_sam/utility.hpp#L155)  ?

Its really nice and neat if all parameters scoped according to their parent nodes, this way you can instantly recognize what parameter belongs to what class. 