### PR TITLE
Remove Point Cloud Queue in imageProjection

### DIFF
--- a/src/imageProjection.cpp
+++ b/src/imageProjection.cpp
@@ -196,14 +196,9 @@ public:
 
     bool cachePointCloud(const sensor_msgs::PointCloud2ConstPtr& laserCloudMsg)
     {
-        // cache point cloud
-        cloudQueue.push_back(*laserCloudMsg);
-        if (cloudQueue.size() <= 2)
-            return false;
-
-        // convert cloud
-        currentCloudMsg = std::move(cloudQueue.front());
-        cloudQueue.pop_front();
+    
+        currentCloudMsg = std::move(*laserCloudMsg);
+        
         if (sensor == SensorType::VELODYNE || sensor == SensorType::LIVOX)
         {
             pcl::moveFromROSMsg(currentCloudMsg, *laserCloudIn);


### PR DESCRIPTION
I saw there was a queue for incoming point cloud messages. I see no benefit of having it in the code. It also ruines the real-time capabilities of the LIO-SAM, by processing messages that are in the past, leads to unwanted delay. I have checked that IMU and ODOM messages can be linked with "timeScanCur" with no problems.
I propose the removal of this queue.