### PR TITLE
ROS2 dockerfile and docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM osrf/ros:humble-desktop-full-jammy
+
+RUN apt-get update \
+    && apt-get install -y curl \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - \
+    && apt-get update \
+    && apt install -y python3-colcon-common-extensions \
+    && apt-get install -y ros-humble-navigation2 \
+    && apt-get install -y ros-humble-robot-localization \
+    && apt-get install -y ros-humble-robot-state-publisher \
+    && apt install -y ros-humble-perception-pcl \
+  	&& apt install -y ros-humble-pcl-msgs \
+  	&& apt install -y ros-humble-vision-opencv \
+  	&& apt install -y ros-humble-xacro \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && apt install -y software-properties-common \
+    && add-apt-repository -y ppa:borglab/gtsam-release-4.1 \
+    && apt-get update \
+    && apt install -y libgtsam-dev libgtsam-unstable-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-c"]
+
+RUN mkdir -p ~/colcon_ws/src \
+    && cd ~/colcon_ws/src \
+    && git clone --branch ros2 https://github.com/TixiaoShan/LIO-SAM.git \
+    && cd .. \
+    && source /opt/ros/humble/setup.bash \
+    && colcon build
+
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc \
+    && echo "source /root/colcon_ws/install/setup.bash" >> /root/.bashrc
+
+WORKDIR /root/colcon_ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update \
 
 SHELL ["/bin/bash", "-c"]
 
-RUN mkdir -p ~/colcon_ws/src \
-    && cd ~/colcon_ws/src \
+RUN mkdir -p ~/ros2_ws/src \
+    && cd ~/ros2_ws/src \
     && git clone --branch ros2 https://github.com/TixiaoShan/LIO-SAM.git \
     && cd .. \
     && source /opt/ros/humble/setup.bash \
     && colcon build
 
 RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc \
-    && echo "source /root/colcon_ws/install/setup.bash" >> /root/.bashrc
+    && echo "source /root/ros2_ws/install/setup.bash" >> /root/.bashrc
 
-WORKDIR /root/colcon_ws
+WORKDIR /root/ros2_ws

--- a/README.md
+++ b/README.md
@@ -97,6 +97,48 @@ Use the following commands to download and compile the package.
   colcon build
   ```
 
+## Using Docker
+
+Build image (based on ROS2 Humble):
+
+```
+docker build -t liosam-humble-jammy .
+```
+
+Once you have the image, you can start a container by using one of the following methods:
+
+1. `docker run`
+
+```
+docker run --init -it -d \
+  --name liosam-humble-jammy-container \
+  -v /etc/localtime:/etc/localtime:ro \
+  -v /etc/timezone:/etc/timezone:ro \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -e DISPLAY=$DISPLAY \
+  --runtime=nvidia --gpus all \
+  liosam-humble-jammy \
+  bash
+```
+
+2. `docker compose`
+
+Start a docker compose container:
+
+```
+docker compose up -d
+```
+
+Stopping a docker compose container:
+```
+docker compose down
+```
+
+To enter into the running container use:
+
+```
+docker exec -it liosam-humble-jammy-container bash
+```
 ## Prepare lidar data
 
 The user needs to prepare the point cloud data in the correct format for cloud deskewing, which is mainly done in "imageProjection.cpp". The two requirements are:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  ddg-humble-container:
+    image: liosam-humble-jammy
+    container_name: liosam-humble-jammy-container
+    privileged: true
+    hostname: liosam-humble-jammy-container
+    restart: always
+    stdin_open: true
+    tty: true
+    network_mode: "host"
+    dns:
+      - 1.1.1.1
+      - 1.0.0.1
+      - 8.8.8.8
+    environment:
+      - "DISPLAY=$DISPLAY"
+      - "NVIDIA_VISIBLE_DEVICES=all"
+      - "NVIDIA_DRIVER_CAPABILITIES=all"
+      - "FASTRTPS_DEFAULT_PROFILES_FILE=/usr/local/share/middleware_profiles/rtps_udp_profile.xml"
+    volumes:
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/dev/*:/dev/*"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]


### PR DESCRIPTION
Added ROS2 dockerfile and docker compose.
Updated instructions in README to run the docker container using the `run` command as well as the compose file. 
I have tried to keep the ROS2 docker setup as similar to the ROS1 setup as possible so that it is easy to use and the setup procedure remains same. 
Also added GPU support in docker.