### PR TITLE
Remove filesystem calls from save_map ROS service

### DIFF
--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -361,9 +361,6 @@ public:
       if(req.destination.empty()) saveMapDirectory = std::getenv("HOME") + savePCDDirectory;
       else saveMapDirectory = std::getenv("HOME") + req.destination;
       cout << "Save destination: " << saveMapDirectory << endl;
-      // create directory and remove old files;
-      int unused = system((std::string("exec rm -r ") + saveMapDirectory).c_str());
-      unused = system((std::string("mkdir -p ") + saveMapDirectory).c_str());
       // save key frame transformations
       pcl::io::savePCDFileBinary(saveMapDirectory + "/trajectory.pcd", *cloudKeyPoses3D);
       pcl::io::savePCDFileBinary(saveMapDirectory + "/transformations.pcd", *cloudKeyPoses6D);


### PR DESCRIPTION
Prevent accidentally erasing directory on your filesystem when calling the save_map ROS service.

pcl::PCDWriter::writerBinary will give a warning if the directory is not existing, but this is better than risking to accidentally erase your home directory.

This is achieved by removing following two lines:

> int unused = system((std::string("exec rm -r ") + saveMapDirectory).c_str());
> unused = system((std::string("mkdir -p ") + saveMapDirectory).c_str());