### PR TITLE
Add support for Velodyne Velarray M1600

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -58,7 +58,7 @@ using namespace std;
 
 typedef pcl::PointXYZI PointType;
 
-enum class SensorType { VELODYNE, OUSTER, LIVOX };
+enum class SensorType { VELODYNE, OUSTER, LIVOX, VELODYNE_M1600 };
 
 class ParamServer
 {
@@ -186,11 +186,14 @@ public:
         else if (sensorStr == "livox")
         {
             sensor = SensorType::LIVOX;
+        } 
+        else if (sensorStr == "velodyne_m1600") {
+            sensor = SensorType::VELODYNE_M1600;
         }
         else
         {
             ROS_ERROR_STREAM(
-                "Invalid sensor type (must be either 'velodyne' or 'ouster' or 'livox'): " << sensorStr);
+                "Invalid sensor type (must be either 'velodyne' or 'ouster' or 'livox' or 'velodyne_m1600'): " << sensorStr);
             ros::shutdown();
         }
 

--- a/src/imageProjection.cpp
+++ b/src/imageProjection.cpp
@@ -1,5 +1,6 @@
 #include "utility.h"
 #include "lio_sam/cloud_info.h"
+#include "pcl/filters/impl/filter.hpp"
 
 struct VelodynePointXYZIRT
 {
@@ -13,6 +14,19 @@ POINT_CLOUD_REGISTER_POINT_STRUCT (VelodynePointXYZIRT,
     (float, x, x) (float, y, y) (float, z, z) (float, intensity, intensity)
     (uint16_t, ring, ring) (float, time, time)
 )
+struct Velodyne_M1600PointXYZIRT {
+   PCL_ADD_POINT4D;
+  uint8_t intensity;
+  uint8_t ring;
+  uint32_t timestampSec;
+  uint32_t timestampNsec;
+  
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+    Velodyne_M1600PointXYZIRT,
+    (float, x, x)(float, y, y)(float, z, z)(uint8_t, intensity, intensity)(
+        uint8_t, ring, ring)(uint32_t, timestampSec, timestampSec)(uint32_t, timestampNsec, timestampNsec))
 
 struct OusterPointXYZIRT {
     PCL_ADD_POINT4D;
@@ -68,6 +82,7 @@ private:
 
     pcl::PointCloud<PointXYZIRT>::Ptr laserCloudIn;
     pcl::PointCloud<OusterPointXYZIRT>::Ptr tmpOusterCloudIn;
+    pcl::PointCloud<Velodyne_M1600PointXYZIRT>::Ptr tmpM1600CloudIn;
     pcl::PointCloud<PointType>::Ptr   fullCloud;
     pcl::PointCloud<PointType>::Ptr   extractedCloud;
 
@@ -108,6 +123,7 @@ public:
     {
         laserCloudIn.reset(new pcl::PointCloud<PointXYZIRT>());
         tmpOusterCloudIn.reset(new pcl::PointCloud<OusterPointXYZIRT>());
+        tmpM1600CloudIn.reset(new pcl::PointCloud<Velodyne_M1600PointXYZIRT>());
         fullCloud.reset(new pcl::PointCloud<PointType>());
         extractedCloud.reset(new pcl::PointCloud<PointType>());
 
@@ -207,7 +223,27 @@ public:
         if (sensor == SensorType::VELODYNE || sensor == SensorType::LIVOX)
         {
             pcl::moveFromROSMsg(currentCloudMsg, *laserCloudIn);
-        }
+        } 
+        else if (sensor == SensorType::VELODYNE_M1600) {
+               
+            pcl::moveFromROSMsg(currentCloudMsg, *tmpM1600CloudIn);
+            laserCloudIn->points.resize(tmpM1600CloudIn->size());
+            laserCloudIn->is_dense = tmpM1600CloudIn->is_dense;
+            double time_begins = tmpM1600CloudIn->points[0].timestampSec;
+            double time_beginns = tmpM1600CloudIn->points[0].timestampNsec;
+            double time_begin = time_begins + (time_beginns * 1e-9);
+            for (size_t i = 0; i < tmpM1600CloudIn->size(); i++) {
+                   auto &src = tmpM1600CloudIn->points[i];
+                   auto &dst = laserCloudIn->points[i];
+                   dst.x = src.x;
+                   dst.y = src.y*-1;
+                   dst.z = src.z*-1;
+                   dst.intensity = static_cast<float>(src.intensity);
+                   dst.ring = src.ring;
+                   double point_time = src.timestampSec + (src.timestampNsec * 1e-9);
+                   dst.time = point_time-time_begin;
+               }
+         }
         else if (sensor == SensorType::OUSTER)
         {
             // Convert to Velodyne format
@@ -236,6 +272,8 @@ public:
         cloudHeader = currentCloudMsg.header;
         timeScanCur = cloudHeader.stamp.toSec();
         timeScanEnd = timeScanCur + laserCloudIn->points.back().time;
+	vector<int> indices;
+        pcl::removeNaNFromPointCloud(*laserCloudIn, *laserCloudIn, indices);
 
         // check dense flag
         if (laserCloudIn->is_dense == false)
@@ -270,7 +308,7 @@ public:
             deskewFlag = -1;
             for (auto &field : currentCloudMsg.fields)
             {
-                if (field.name == "time" || field.name == "t")
+                if (field.name == "time" || field.name == "t" || field.name == "timestamp" || field.name == "timestampSec")
                 {
                     deskewFlag = 1;
                     break;
@@ -554,7 +592,17 @@ public:
             {
                 columnIdn = columnIdnCountVec[rowIdn];
                 columnIdnCountVec[rowIdn] += 1;
+            } else if (sensor == SensorType::VELODYNE_M1600) {
+                
+                float horizonAngle = atan2(thisPoint.x, thisPoint.y) * 180 / M_PI;
+                
+                float ang_res_x = 0.29; // or 0.33 for the extended model, as per the specifications
+                
+                columnIdn = round((horizonAngle / ang_res_x) + (Horizon_SCAN / 2));
+                if (columnIdn >= Horizon_SCAN)
+                    columnIdn -= Horizon_SCAN;
             }
+            
             
             if (columnIdn < 0 || columnIdn >= Horizon_SCAN)
                 continue;


### PR DESCRIPTION
I've implemented support for the [Velodyne velarray M1600](https://velodynelidar.com/products/velarray-m1600/), solid-state LiDAR by modifying the imageProjection.cpp and utility.h files. This pull request aims to integrate the functionality necessary for utilizing the Velarray M1600 within the existing framework.
For testing purposes, I've utilized a [dataset](https://zenodo.org/records/7913307), which includes data from a Velodyne Velarray M1600 and a 6-axis IMU, but it should work in a 9-axis-imu!
In the testing configuration, the following values were utilized:
[params_m1600.txt](https://github.com/TixiaoShan/LIO-SAM/files/14726798/params_m1600.txt)
For the Horizon_SCAN, i consider 3077 points.
Results Snapshot:
![Lio_SAM_M1600](https://github.com/TixiaoShan/LIO-SAM/assets/146146031/3cac5537-4f8d-450e-bc15-db351e64a812)
This image showcases some of the results obtained through the integration of the Velodyne Velarray M1600.




