### PR TITLE
add the missing line in the resetParameters() function of the ImagePr…

### DIFF
--- a/src/imageProjection.cpp
+++ b/src/imageProjection.cpp
@@ -169,6 +169,7 @@ public:
             imuRotY[i] = 0;
             imuRotZ[i] = 0;
         }
+        columnIdnCountVec.assign(N_SCAN, 0);
     }
 
     ~ImageProjection(){}


### PR DESCRIPTION
Add the missing line

`columnIdnCountVec.assign(N_SCAN, 0);`

 in the _resetParameters_ function of the _ImageProjection_ class in the _imageProjection.cpp_ file