### PR TITLE
Update utility.h

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -15,8 +15,6 @@
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <opencv/cv.h>
-
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/search/impl/search.hpp>
@@ -30,6 +28,9 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/filters/crop_box.h> 
 #include <pcl_conversions/pcl_conversions.h>
+
+// #include <opencv/cv.h>
+#include <opencv2/opencv.hpp> 
 
 #include <tf/LinearMath/Quaternion.h>
 #include <tf/transform_listener.h>


### PR DESCRIPTION
In ROS1 Noetic
Configure the utility.h to use #include <opencv2/opencv.hpp> instead of #include <opencv/cv.h> 
Move #include <opencv2/opencv.hpp> after the pcl headers